### PR TITLE
Load error codes async

### DIFF
--- a/bosch_thermostat_client/db/__init__.py
+++ b/bosch_thermostat_client/db/__init__.py
@@ -9,6 +9,7 @@ from bosch_thermostat_client.const import DEFAULT, FIRMWARE_VERSION
 from bosch_thermostat_client.const.nefit import NEFIT
 from bosch_thermostat_client.const.ivt import (
     CAN,
+    IVT,
     NSC_ICOM_GATEWAY,
     RC300_RC200,
     MBLAN,
@@ -86,3 +87,14 @@ def get_nefit_errors() -> dict:
 def get_easycontrol_errors() -> dict:
     """Get error codes of EASYCONTROL devices."""
     return open_json(os.path.join(MAINPATH, "errorcodes_easycontrol.json"))
+
+
+async def async_get_errors(device_type) -> dict:
+    """Get error codes of all devices."""
+    if device_type == EASYCONTROL:
+        return await asyncio.to_thread(get_easycontrol_errors)
+    elif device_type == NEFIT:
+        return await asyncio.to_thread(get_nefit_errors)
+    elif device_type == IVT:
+        return (await asyncio.to_thread(get_nefit_errors)) | (await asyncio.to_thread(get_ivt_errors))
+    return {}

--- a/bosch_thermostat_client/gateway/base.py
+++ b/bosch_thermostat_client/gateway/base.py
@@ -31,7 +31,7 @@ from bosch_thermostat_client.const import (
     CRAWL_SENSORS,
     SWITCHES,
 )
-from bosch_thermostat_client.db import get_custom_db, get_db_of_firmware, get_initial_db
+from bosch_thermostat_client.db import get_custom_db, get_db_of_firmware, get_initial_db, async_get_errors
 from bosch_thermostat_client.exceptions import (
     DeviceException,
     FirmwareException,
@@ -49,6 +49,9 @@ _LOGGER = logging.getLogger(__name__)
 class BaseGateway:
     """Base Gateway class."""
 
+    device_type: str
+    circuit_types: dict[str, str]
+
     def __init__(self, host):
         """BaseGateway constructor
 
@@ -63,6 +66,7 @@ class BaseGateway:
         self._initialized = None
         self.initialization_msg = None
         self._bus_type = None
+        self_errors = None
 
     async def get_base_db(self):
         return await get_initial_db(self.device_type)
@@ -82,6 +86,7 @@ class BaseGateway:
                 )
                 initial_db.pop(MODELS, None)
                 self._db.update(initial_db)
+                self._errors = await async_get_errors(self.device_type)
                 self._initialized = True
                 return
             raise FirmwareException(
@@ -273,7 +278,7 @@ class BaseGateway:
         """Initialize sensors objects."""
         if SENSORS in self._db:
             self._data[SENSORS] = Sensors(
-                connector=self._connector, sensors_db=self._db[SENSORS]
+                connector=self._connector, sensors_db=self._db[SENSORS], errors=self._errors
             )
         if CRAWL_SENSORS in self._db:
             _LOGGER.info("Initializing Crawl Sensors.")

--- a/bosch_thermostat_client/gateway/base.py
+++ b/bosch_thermostat_client/gateway/base.py
@@ -66,7 +66,7 @@ class BaseGateway:
         self._initialized = None
         self.initialization_msg = None
         self._bus_type = None
-        self_errors = None
+        self._errors = None
 
     async def get_base_db(self):
         return await get_initial_db(self.device_type)

--- a/bosch_thermostat_client/sensors/notification_easycontrol.py
+++ b/bosch_thermostat_client/sensors/notification_easycontrol.py
@@ -10,7 +10,15 @@ from bosch_thermostat_client.const import (
 
 
 class NotificationSensor(Sensor):
-    errorcodes = get_easycontrol_errors()
+    errorcodes: dict
+
+    def __init__(
+        self,
+        **kwargs,
+    ) -> None:
+        """Notification sensor init."""
+        super().__init__(**kwargs)
+        self.errorcodes = kwargs.get("errorcodes", {})
 
     def get_error_message(self, dcd: str, ccd: str, act: str, fc: str) -> str:
         msg = "Unknown error"

--- a/bosch_thermostat_client/sensors/notification_ivt.py
+++ b/bosch_thermostat_client/sensors/notification_ivt.py
@@ -9,7 +9,15 @@ from bosch_thermostat_client.const import (
 
 
 class NotificationSensor(Sensor):
-    errorcodes = get_nefit_errors() | get_ivt_errors()
+    errorcodes: dict
+
+    def __init__(
+        self,
+        **kwargs,
+    ) -> None:
+        """Notification sensor init."""
+        super().__init__(**kwargs)
+        self.errorcodes = kwargs.get("errorcodes", {})
 
     def process_results(self, result, key=None, return_data=False):
         """Convert multi-level json object to one level object."""

--- a/bosch_thermostat_client/sensors/notification_nefit.py
+++ b/bosch_thermostat_client/sensors/notification_nefit.py
@@ -11,7 +11,7 @@ from bosch_thermostat_client.const import (
 
 
 class NotificationSensor(Sensor):
-    errorcodes = get_nefit_errors()
+    errorcodes: dict
     _allowed_types = "notification"
 
     def __init__(
@@ -42,6 +42,7 @@ class NotificationSensor(Sensor):
             attr_id: {RESULT: {}, URI: path, TYPE: kind},
             "cause": {RESULT: {}, URI: cause_uri, TYPE: kind},
         }
+        self.errorcodes = kwargs.get("errorcodes", {})
 
     @property
     def state(self):

--- a/bosch_thermostat_client/sensors/sensors.py
+++ b/bosch_thermostat_client/sensors/sensors.py
@@ -60,7 +60,7 @@ class Sensors(BoschEntities):
     """Sensors object containing multiple Sensor objects."""
 
     def __init__(
-        self, connector, sensors_db={}, uri_prefix=None, data=None, parent=None
+        self, connector, sensors_db: dict | None = None, uri_prefix=None, data=None, parent=None, errors: dict | None = None
     ):
         """
         Initialize sensors.
@@ -71,7 +71,7 @@ class Sensors(BoschEntities):
         super().__init__(connector.get)
         self._items = {}
 
-        for sensor_id, sensor in sensors_db.items():
+        for sensor_id, sensor in (sensors_db or {}).items():
             if sensor_id not in self._items:
                 kwargs = {
                     "connector": connector,
@@ -87,6 +87,8 @@ class Sensors(BoschEntities):
                     "parent": parent,
                     **sensor,
                 }
+                if sensor_id == NOTIFICATIONS and errors:
+                    kwargs["errorcodes"] = errors
                 SensorClass = get_sensor_class(
                     device_type=connector.device_type, sensor_type=sensor_id
                 )


### PR DESCRIPTION
Update to load error codes from JSON async:
- Load JSONs while setting up the respective gateway via `BaseGateway`
- Pass errors to created Sensors
- If `sensor_type == 'notifications'`, pass errors to actual sensor
- Adjust `__init__()` of sensors to store the errors

Tested this on a CT200 with the other changes of 
- https://github.com/bosch-thermostat/bosch-thermostat-client-python/pull/43
- https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/pull/424
- https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/pull/425
and haven't seen an async error again. 

I don't have any notifications but I have verified locally using a logger that `self.errorcodes` in the notification sensors is filled.